### PR TITLE
Update jna dependency to restore native file watching on Macs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
     <dependency>
       <groupId>net.java.dev.jna</groupId>
       <artifactId>jna</artifactId>
-      <version>3.2.2</version>
+      <version>5.6.0</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
@@ -155,8 +155,8 @@
           <artifactId>maven-compiler-plugin</artifactId>
           <version>3.1</version>
           <configuration>
-            <source>1.6</source>
-            <target>1.6</target>
+            <source>1.7</source>
+            <target>1.7</target>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
Mac OS 11 (aka. "Big Sur") made some changes to the way that the Carbon library is located, causing JNA calls to fail. This has been fixed in JNA 5.6.0; see https://github.com/java-native-access/jna/pull/1216

Since Barbary is implemented on JNA, this is causing downstream projects that rely on file watching to crash on JVM start when used on Mac OS 11.

Examples:
- https://github.com/bhauman/figwheel-main/issues/253
- https://github.com/thheller/shadow-cljs/issues/767